### PR TITLE
feat: Phase 13 高度なテーマカスタマイズ機能実装

### DIFF
--- a/src/components/atoms/ColorPicker.tsx
+++ b/src/components/atoms/ColorPicker.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+interface ColorPickerProps {
+  label?: string;
+  value: string;
+  onChange: (color: string) => void;
+  id?: string;
+}
+
+export const ColorPicker: React.FC<ColorPickerProps> = ({
+  label,
+  value,
+  onChange,
+  id,
+}) => {
+  const pickerId = id || `color-picker-${Math.random().toString(36).substring(2, 11)}`;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {label && (
+        <label
+          htmlFor={pickerId}
+          className="text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          {label}
+        </label>
+      )}
+      <div className="flex items-center gap-3">
+        <input
+          id={pickerId}
+          type="color"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="w-12 h-12 rounded-lg cursor-pointer border-2 border-gray-300 dark:border-gray-600"
+          aria-label={label || 'カラーピッカー'}
+        />
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="flex-1 px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="#000000"
+          pattern="^#[0-9A-Fa-f]{6}$"
+          aria-label={`${label || 'カラー'}のHEXコード`}
+        />
+      </div>
+    </div>
+  );
+};
+
+ColorPicker.displayName = 'ColorPicker';

--- a/src/components/molecules/CustomColorSettings.tsx
+++ b/src/components/molecules/CustomColorSettings.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { ColorPicker } from '../atoms/ColorPicker';
+import type { ColorScheme } from '../../types';
+
+interface CustomColorSettingsProps {
+  colors: ColorScheme;
+  onColorChange: (key: keyof ColorScheme, value: string) => void;
+}
+
+export const CustomColorSettings: React.FC<CustomColorSettingsProps> = ({
+  colors,
+  onColorChange,
+}) => {
+  const colorFields: Array<{ key: keyof ColorScheme; label: string }> = [
+    { key: 'senderBubble', label: '送信者バブル' },
+    { key: 'receiverBubble', label: '受信者バブル' },
+    { key: 'primary', label: 'プライマリ' },
+    { key: 'background', label: '背景' },
+    { key: 'text', label: 'テキスト' },
+  ];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+        カスタムカラー
+      </h3>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {colorFields.map((field) => (
+          <ColorPicker
+            key={field.key}
+            label={field.label}
+            value={colors[field.key]}
+            onChange={(value) => onColorChange(field.key, value)}
+            id={`color-${field.key}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+CustomColorSettings.displayName = 'CustomColorSettings';

--- a/src/components/molecules/ThemePresetSelector.tsx
+++ b/src/components/molecules/ThemePresetSelector.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { getAllThemePresets, type ThemePreset } from '../../constants/themePresets';
+
+interface ThemePresetSelectorProps {
+  onSelectPreset: (preset: ThemePreset) => void;
+  currentPresetId?: string;
+}
+
+export const ThemePresetSelector: React.FC<ThemePresetSelectorProps> = ({
+  onSelectPreset,
+  currentPresetId,
+}) => {
+  const presets = getAllThemePresets();
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+        テーマプリセット
+      </h3>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {presets.map((preset) => {
+          const isActive = currentPresetId === preset.id;
+          return (
+            <button
+              key={preset.id}
+              onClick={() => onSelectPreset(preset)}
+              className={`
+                flex flex-col gap-2 p-4 rounded-lg border-2 transition-all
+                ${
+                  isActive
+                    ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
+                    : 'border-gray-300 dark:border-gray-600 hover:border-blue-300 dark:hover:border-blue-700'
+                }
+              `}
+              aria-pressed={isActive}
+              aria-label={`${preset.name}テーマを選択`}
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-medium text-gray-900 dark:text-gray-100">
+                  {preset.name}
+                </span>
+                {isActive && (
+                  <span className="text-blue-500" aria-label="選択中">
+                    ✓
+                  </span>
+                )}
+              </div>
+              <p className="text-sm text-gray-600 dark:text-gray-400 text-left">
+                {preset.description}
+              </p>
+              <div className="flex gap-2 mt-2">
+                <div
+                  className="w-8 h-8 rounded-full border border-gray-300"
+                  style={{ backgroundColor: preset.colors.senderBubble }}
+                  aria-label="送信者バブルカラー"
+                />
+                <div
+                  className="w-8 h-8 rounded-full border border-gray-300"
+                  style={{ backgroundColor: preset.colors.receiverBubble }}
+                  aria-label="受信者バブルカラー"
+                />
+                <div
+                  className="w-8 h-8 rounded-full border border-gray-300"
+                  style={{ backgroundColor: preset.colors.primary }}
+                  aria-label="プライマリカラー"
+                />
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+ThemePresetSelector.displayName = 'ThemePresetSelector';

--- a/src/constants/themePresets.ts
+++ b/src/constants/themePresets.ts
@@ -1,0 +1,103 @@
+/**
+ * SNSプリセットテーマ定義
+ */
+
+import type { ColorScheme } from '../types';
+
+export interface ThemePreset {
+  id: string;
+  name: string;
+  description: string;
+  colors: ColorScheme;
+}
+
+export const THEME_PRESETS: Record<string, ThemePreset> = {
+  line: {
+    id: 'line',
+    name: 'LINE風',
+    description: 'LINEのような緑ベースのデザイン',
+    colors: {
+      primary: '#06C755',
+      secondary: '#00B900',
+      background: '#FFFFFF',
+      surface: '#F7F7F7',
+      text: '#1A1A1A',
+      textSecondary: '#8E8E93',
+      senderBubble: '#06C755',
+      receiverBubble: '#F0F0F0',
+      border: '#E5E5EA',
+    },
+  },
+  instagram: {
+    id: 'instagram',
+    name: 'Instagram風',
+    description: 'Instagramのようなグラデーションデザイン',
+    colors: {
+      primary: '#E1306C',
+      secondary: '#F77737',
+      background: '#FAFAFA',
+      surface: '#FFFFFF',
+      text: '#262626',
+      textSecondary: '#8E8E8E',
+      senderBubble: '#E1306C',
+      receiverBubble: '#EFEFEF',
+      border: '#DBDBDB',
+    },
+  },
+  twitter: {
+    id: 'twitter',
+    name: 'X (Twitter)風',
+    description: 'X (旧Twitter)のような青ベースのデザイン',
+    colors: {
+      primary: '#1DA1F2',
+      secondary: '#14171A',
+      background: '#FFFFFF',
+      surface: '#F7F9F9',
+      text: '#14171A',
+      textSecondary: '#657786',
+      senderBubble: '#1DA1F2',
+      receiverBubble: '#E1E8ED',
+      border: '#E1E8ED',
+    },
+  },
+  discord: {
+    id: 'discord',
+    name: 'Discord風',
+    description: 'Discordのようなダークテーマ',
+    colors: {
+      primary: '#5865F2',
+      secondary: '#4752C4',
+      background: '#36393F',
+      surface: '#2F3136',
+      text: '#DCDDDE',
+      textSecondary: '#B9BBBE',
+      senderBubble: '#5865F2',
+      receiverBubble: '#40444B',
+      border: '#202225',
+    },
+  },
+  slack: {
+    id: 'slack',
+    name: 'Slack風',
+    description: 'Slackのようなビジネスデザイン',
+    colors: {
+      primary: '#4A154B',
+      secondary: '#36C5F0',
+      background: '#FFFFFF',
+      surface: '#F8F8F8',
+      text: '#1D1C1D',
+      textSecondary: '#616061',
+      senderBubble: '#4A154B',
+      receiverBubble: '#F4EDE4',
+      border: '#E0E0E0',
+    },
+  },
+};
+
+export const getThemePreset = (id: string): ThemePreset | undefined => {
+  return THEME_PRESETS[id];
+};
+
+export const getAllThemePresets = (): ThemePreset[] => {
+  return Object.values(THEME_PRESETS);
+};


### PR DESCRIPTION
## Phase 13: テーマプリセットとカスタムカラー

### プリセットテーマ追加
- LINE風: 緑ベースのデザイン (#06C755)
- Instagram風: ピンクベースのデザイン (#E1306C)
- X (Twitter)風: 青ベースのデザイン (#1DA1F2)
- Discord風: ダークテーマデザイン (#5865F2)
- Slack風: ビジネスデザイン (#4A154B)

### 新規コンポーネント
- ColorPicker: カラーピッカー + HEX入力
- ThemePresetSelector: プリセット選択UI
- CustomColorSettings: カスタムカラー設定

### themeStore拡張
- applyPreset(): プリセットテーマ適用
- updateColor(): 個別カラー更新
- exportTheme(): テーマJSON出力
- importTheme(): テーマJSONインポート
- currentPresetId: 選択中プリセット追跡

### 技術詳細
- themePresets.ts: プリセット定義ファイル
- ColorScheme型: 統一されたカラースキーマ
- Zustand永続化: LocalStorageでテーマ保存
- プリセット/カスタム切り替え: 柔軟なテーマ管理

ビルドサイズ: 416KB (gzip: 116KB)
型チェック・ビルド成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)