### PR TITLE
feat: Phase 14 レスポンシブデザイン強化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sns-chat-mockup-generator",
       "version": "0.0.0",
       "dependencies": {
+        "clsx": "^2.1.1",
         "html2canvas": "^1.4.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -2177,6 +2178,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "clsx": "^2.1.1",
     "html2canvas": "^1.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/components/templates/MainTemplate.tsx
+++ b/src/components/templates/MainTemplate.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useBreakpoint } from '../../hooks/useMediaQuery';
 
 interface MainTemplateProps {
   header?: React.ReactNode;
@@ -13,14 +14,35 @@ export const MainTemplate: React.FC<MainTemplateProps> = ({
   messageComposer,
   controlPanel,
 }) => {
-  return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4">
-      <div className="max-w-7xl mx-auto space-y-4">
-        {header && <header>{header}</header>}
+  const { isMobile, isTablet } = useBreakpoint();
+  const [showControlPanel, setShowControlPanel] = useState(false);
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="max-w-7xl mx-auto">
+        {header && <header className="p-2 sm:p-4">{header}</header>}
+
+        {/* モバイル: コントロールパネル切り替えボタン */}
+        {(isMobile || isTablet) && (
+          <div className="p-2 sm:p-4">
+            <button
+              onClick={() => setShowControlPanel(!showControlPanel)}
+              className="w-full py-3 px-4 bg-blue-500 text-white rounded-lg font-medium hover:bg-blue-600 transition-colors"
+              aria-expanded={showControlPanel}
+              aria-controls="control-panel"
+            >
+              {showControlPanel ? '設定を閉じる' : '設定を開く'}
+            </button>
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-2 sm:gap-4 p-2 sm:p-4">
           {/* メイン作業エリア */}
-          <div className="lg:col-span-2 space-y-4">
+          <div
+            className={`lg:col-span-2 space-y-2 sm:space-y-4 ${
+              (isMobile || isTablet) && showControlPanel ? 'hidden' : ''
+            }`}
+          >
             <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden">
               {chatWindow}
             </div>
@@ -28,7 +50,14 @@ export const MainTemplate: React.FC<MainTemplateProps> = ({
           </div>
 
           {/* コントロールパネル */}
-          <div className="lg:col-span-1">{controlPanel}</div>
+          <div
+            id="control-panel"
+            className={`lg:col-span-1 ${
+              (isMobile || isTablet) && !showControlPanel ? 'hidden' : ''
+            }`}
+          >
+            {controlPanel}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/templates/ResponsiveContainer.tsx
+++ b/src/components/templates/ResponsiveContainer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import clsx from 'clsx';
 import { useBreakpoint } from '../../hooks/useMediaQuery';
 
 interface ResponsiveContainerProps {
@@ -12,13 +13,15 @@ export const ResponsiveContainer: React.FC<ResponsiveContainerProps> = ({
 }) => {
   const { isMobile, isTablet, isDesktop } = useBreakpoint();
 
-  const containerClasses = `
-    w-full min-h-screen
-    ${isMobile ? 'px-2 py-4' : ''}
-    ${isTablet ? 'px-6 py-6' : ''}
-    ${isDesktop ? 'px-8 py-8 max-w-7xl mx-auto' : ''}
-    ${className}
-  `;
+  const containerClasses = clsx(
+    'w-full min-h-screen',
+    {
+      'px-2 py-4': isMobile,
+      'px-6 py-6': isTablet,
+      'px-8 py-8 max-w-7xl mx-auto': isDesktop,
+    },
+    className
+  );
 
   return (
     <div className={containerClasses}>

--- a/src/components/templates/ResponsiveContainer.tsx
+++ b/src/components/templates/ResponsiveContainer.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useBreakpoint } from '../../hooks/useMediaQuery';
+
+interface ResponsiveContainerProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const ResponsiveContainer: React.FC<ResponsiveContainerProps> = ({
+  children,
+  className = '',
+}) => {
+  const { isMobile, isTablet, isDesktop } = useBreakpoint();
+
+  const containerClasses = `
+    w-full min-h-screen
+    ${isMobile ? 'px-2 py-4' : ''}
+    ${isTablet ? 'px-6 py-6' : ''}
+    ${isDesktop ? 'px-8 py-8 max-w-7xl mx-auto' : ''}
+    ${className}
+  `;
+
+  return (
+    <div className={containerClasses}>
+      {children}
+    </div>
+  );
+};
+
+ResponsiveContainer.displayName = 'ResponsiveContainer';

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect } from 'react';
+
+export const useMediaQuery = (query: string): boolean => {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+
+    // 初期値を設定
+    setMatches(media.matches);
+
+    // リスナーを追加
+    const listener = (event: MediaQueryListEvent) => {
+      setMatches(event.matches);
+    };
+
+    // Safari 13以前の互換性のため、両方のAPIをサポート
+    if (media.addEventListener) {
+      media.addEventListener('change', listener);
+    } else {
+      media.addListener(listener);
+    }
+
+    return () => {
+      if (media.removeEventListener) {
+        media.removeEventListener('change', listener);
+      } else {
+        media.removeListener(listener);
+      }
+    };
+  }, [query]);
+
+  return matches;
+};
+
+// プリセットのブレークポイント
+export const useBreakpoint = () => {
+  const isMobile = useMediaQuery('(max-width: 767px)');
+  const isTablet = useMediaQuery('(min-width: 768px) and (max-width: 1023px)');
+  const isDesktop = useMediaQuery('(min-width: 1024px)');
+  const isSmallMobile = useMediaQuery('(max-width: 389px)');
+  const isLargeMobile = useMediaQuery('(min-width: 390px) and (max-width: 767px)');
+
+  return {
+    isMobile,
+    isTablet,
+    isDesktop,
+    isSmallMobile,
+    isLargeMobile,
+  };
+};


### PR DESCRIPTION
## Phase 14: 完全レスポンシブ対応

### カスタムフック
- useMediaQuery: メディアクエリ対応フック
- useBreakpoint: ブレークポイント判定フック
  - isMobile (< 768px)
  - isTablet (768px - 1023px)
  - isDesktop (>= 1024px)
  - isSmallMobile (< 390px)
  - isLargeMobile (390px - 767px)

### 新規コンポーネント
- ResponsiveContainer: レスポンシブコンテナ
  - モバイル: px-2 py-4
  - タブレット: px-6 py-6
  - デスクトップ: px-8 py-8 max-w-7xl

### MainTemplate改善
- モバイル/タブレット: コントロールパネル切り替えボタン
- レスポンシブグリッドレイアウト
- 設定パネルのトグル機能
- aria-expanded, aria-controls対応

## ブレークポイント
- モバイル: < 768px
- タブレット: 768px - 1023px
- デスクトップ: >= 1024px
- 小型モバイル: < 390px

## 技術詳細
- window.matchMedia API使用
- Safari互換性対応（addEventListener/addListener両対応）
- レスポンシブギャップ: gap-2 (mobile) → gap-4 (desktop)
- 動的クラス切り替えでUX向上

ビルドサイズ: 417KB (gzip: 117KB)
型チェック・ビルド成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)