### PR TITLE
feat: Phase 15 最終統合 - テーマカスタマイズUI完全統合

### DIFF
--- a/src/components/organisms/ControlPanel.tsx
+++ b/src/components/organisms/ControlPanel.tsx
@@ -1,13 +1,20 @@
-import React from 'react';
-import type { SnsTheme, DesignOptions } from '../../types';
+import React, { useState } from 'react';
+import type { SnsTheme, DesignOptions, ColorScheme } from '../../types';
+import type { ThemePreset } from '../../constants/themePresets';
 import { ThemeSelector } from '../molecules/ThemeSelector';
+import { ThemePresetSelector } from '../molecules/ThemePresetSelector';
+import { CustomColorSettings } from '../molecules/CustomColorSettings';
 import { DesignControls } from '../molecules/DesignControls';
 import { Button } from '../atoms/Button';
 
 interface ControlPanelProps {
   currentTheme: SnsTheme;
   designOptions: DesignOptions;
+  colors: ColorScheme;
+  currentPresetId: string | null;
   onThemeChange: (theme: SnsTheme) => void;
+  onPresetChange: (preset: ThemePreset) => void;
+  onColorChange: (key: keyof ColorScheme, value: string) => void;
   onToggleAvatar: (show: boolean) => void;
   onToggleTimestamp: (show: boolean) => void;
   onToggleSenderName: (show: boolean) => void;
@@ -16,12 +23,18 @@ interface ControlPanelProps {
   onClear: () => void;
   onExportJSON: () => void;
   onImportJSON: () => void;
+  onExportTheme: () => void;
+  onImportTheme: () => void;
 }
 
 export const ControlPanel: React.FC<ControlPanelProps> = ({
   currentTheme,
   designOptions,
+  colors,
+  currentPresetId,
   onThemeChange,
+  onPresetChange,
+  onColorChange,
   onToggleAvatar,
   onToggleTimestamp,
   onToggleSenderName,
@@ -30,18 +43,48 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
   onClear,
   onExportJSON,
   onImportJSON,
+  onExportTheme,
+  onImportTheme,
 }) => {
+  const [showColorSettings, setShowColorSettings] = useState(false);
+
   return (
     <div className="bg-gray-50 dark:bg-gray-800 p-4 rounded-lg space-y-6">
       <h2 className="text-lg font-bold text-gray-900 dark:text-white">
         設定パネル
       </h2>
 
+      {/* テーマプリセット */}
+      <div className="space-y-4">
+        <ThemePresetSelector
+          onSelectPreset={onPresetChange}
+          currentPresetId={currentPresetId || undefined}
+        />
+      </div>
+
+      {/* カスタムカラー設定 */}
+      <div className="space-y-2">
+        <button
+          onClick={() => setShowColorSettings(!showColorSettings)}
+          className="w-full py-2 px-4 bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white rounded-lg font-medium hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+        >
+          {showColorSettings ? 'カスタムカラーを閉じる' : 'カスタムカラーを開く'}
+        </button>
+        {showColorSettings && (
+          <CustomColorSettings
+            colors={colors}
+            onColorChange={onColorChange}
+          />
+        )}
+      </div>
+
+      {/* 従来のテーマセレクター（後方互換性のため残す） */}
       <ThemeSelector
         currentTheme={currentTheme}
         onThemeChange={onThemeChange}
       />
 
+      {/* デザインオプション */}
       <DesignControls
         options={designOptions}
         onToggleAvatar={onToggleAvatar}
@@ -50,16 +93,31 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
         onToggleStatus={onToggleStatus}
       />
 
+      {/* エクスポート/インポート */}
       <div className="space-y-2 pt-4 border-t border-gray-200 dark:border-gray-700">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+          画像・データ
+        </h3>
         <Button variant="primary" fullWidth onClick={onExport}>
           📥 画像として保存
         </Button>
         <div className="grid grid-cols-2 gap-2">
           <Button variant="outline" fullWidth onClick={onExportJSON}>
-            💾 JSON保存
+            💾 データ保存
           </Button>
           <Button variant="outline" fullWidth onClick={onImportJSON}>
-            📂 JSON読込
+            📂 データ読込
+          </Button>
+        </div>
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 pt-2">
+          テーマ
+        </h3>
+        <div className="grid grid-cols-2 gap-2">
+          <Button variant="outline" fullWidth onClick={onExportTheme}>
+            🎨 テーマ保存
+          </Button>
+          <Button variant="outline" fullWidth onClick={onImportTheme}>
+            🎨 テーマ読込
           </Button>
         </div>
         <Button variant="outline" fullWidth onClick={onClear}>

--- a/src/components/pages/MainPage.tsx
+++ b/src/components/pages/MainPage.tsx
@@ -25,7 +25,7 @@ export const MainPage: React.FC = () => {
     createRoom,
     importRoom,
   } = useMessageStore();
-  const { config, setSnsTheme } = useThemeStore();
+  const { config, currentPresetId, setSnsTheme, applyPreset, updateColor, exportTheme, importTheme } = useThemeStore();
   const {
     options,
     setShowAvatar,
@@ -147,6 +147,26 @@ export const MainPage: React.FC = () => {
     }
   }, [importRoom]);
 
+  const handleExportTheme = useCallback(() => {
+    const themeJSON = exportTheme();
+    const blob = new Blob([themeJSON], { type: 'application/json' });
+    const fileName = `theme-${new Date().toISOString().slice(0, 10)}.json`;
+    downloadBlob(blob, fileName);
+  }, [exportTheme]);
+
+  const handleImportTheme = useCallback(async () => {
+    const file = await selectFile('application/json');
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+      importTheme(text);
+      alert('テーマを読み込みました');
+    } catch (error) {
+      alert(`テーマの読み込みに失敗しました: ${error}`);
+    }
+  }, [importTheme]);
+
   // キーボードショートカット設定
   useKeyboardShortcuts([
     {
@@ -207,7 +227,11 @@ export const MainPage: React.FC = () => {
         <ControlPanel
           currentTheme={config.snsTheme}
           designOptions={options}
+          colors={config.colors}
+          currentPresetId={currentPresetId}
           onThemeChange={setSnsTheme}
+          onPresetChange={applyPreset}
+          onColorChange={updateColor}
           onToggleAvatar={setShowAvatar}
           onToggleTimestamp={setShowTimestamp}
           onToggleSenderName={setShowSenderName}
@@ -216,6 +240,8 @@ export const MainPage: React.FC = () => {
           onClear={handleClear}
           onExportJSON={handleExportJSON}
           onImportJSON={handleImportJSON}
+          onExportTheme={handleExportTheme}
+          onImportTheme={handleImportTheme}
         />
       }
     />


### PR DESCRIPTION
## Phase 15: 最終統合

### ControlPanel完全実装
- ThemePresetSelector統合 (5つのSNSテーマプリセット)
- CustomColorSettings追加 (折りたたみ式カスタムカラー設定)
- テーマimport/exportボタン追加
- 新規props追加:
  - colors: ColorScheme
  - currentPresetId: string | null
  - onPresetChange: (preset: ThemePreset) => void
  - onColorChange: (key: keyof ColorScheme, value: string) => void
  - onExportTheme: () => void
  - onImportTheme: () => void

### MainPage完全統合
- themeStoreメソッド統合:
  - currentPresetId, applyPreset, updateColor, exportTheme, importTheme
- handleExportTheme実装 (JSON形式でテーマ保存)
- handleImportTheme実装 (JSONファイルからテーマ読込)
- ControlPanelへ全テーマ関連propsを渡す

## 技術詳細
- テーマエクスポート: JSON Blob → ダウンロード
- テーマインポート: File API → importTheme()
- カスタムカラー: 折りたたみ式UI (useState)
- プリセット選択: 即座に適用

Phase 13で実装した全テーマ機能がUIに完全統合されました。

ビルドサイズ: 422KB (gzip: 118KB)
型チェック・ビルド成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)