### PR TITLE
feat: Phase 18 メッセージテンプレート機能実装

### DIFF
--- a/src/components/molecules/MessageInput.tsx
+++ b/src/components/molecules/MessageInput.tsx
@@ -6,19 +6,37 @@ interface MessageInputProps {
   onSend: (content: string) => void;
   placeholder?: string;
   disabled?: boolean;
+  value?: string;
+  onChange?: (value: string) => void;
 }
 
 export const MessageInput: React.FC<MessageInputProps> = ({
   onSend,
   placeholder = 'メッセージを入力...',
   disabled = false,
+  value: externalValue,
+  onChange: externalOnChange,
 }) => {
-  const [content, setContent] = useState('');
+  const [internalValue, setInternalValue] = useState('');
+
+  // 制御コンポーネントか非制御コンポーネントかを判定
+  const isControlled = externalValue !== undefined;
+  const content = isControlled ? externalValue : internalValue;
+
+  const handleChange = (newValue: string) => {
+    if (isControlled && externalOnChange) {
+      externalOnChange(newValue);
+    } else {
+      setInternalValue(newValue);
+    }
+  };
 
   const handleSend = () => {
     if (content.trim()) {
       onSend(content.trim());
-      setContent('');
+      if (!isControlled) {
+        setInternalValue('');
+      }
     }
   };
 
@@ -33,7 +51,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     <div className="flex gap-2 items-end">
       <Textarea
         value={content}
-        onChange={(e) => setContent(e.target.value)}
+        onChange={(e) => handleChange(e.target.value)}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
         disabled={disabled}

--- a/src/components/molecules/TemplateSelector.tsx
+++ b/src/components/molecules/TemplateSelector.tsx
@@ -1,0 +1,172 @@
+import React, { useState } from 'react';
+import { useTemplateStore } from '../../stores';
+import { Button } from '../atoms/Button';
+
+interface TemplateSelectorProps {
+  onSelectTemplate: (content: string) => void;
+}
+
+export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
+  onSelectTemplate,
+}) => {
+  const { templates, addTemplate, deleteTemplate } = useTemplateStore();
+  const [showTemplates, setShowTemplates] = useState(false);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [newTemplateName, setNewTemplateName] = useState('');
+  const [newTemplateContent, setNewTemplateContent] = useState('');
+  const [newTemplateCategory, setNewTemplateCategory] = useState('');
+
+  const handleAddTemplate = () => {
+    if (newTemplateName.trim() && newTemplateContent.trim()) {
+      addTemplate(
+        newTemplateName.trim(),
+        newTemplateContent.trim(),
+        newTemplateCategory.trim() || undefined
+      );
+      setNewTemplateName('');
+      setNewTemplateContent('');
+      setNewTemplateCategory('');
+      setShowAddForm(false);
+    }
+  };
+
+  const handleDeleteTemplate = (id: string) => {
+    if (confirm('このテンプレートを削除しますか？')) {
+      deleteTemplate(id);
+    }
+  };
+
+  // カテゴリーでグループ化
+  const groupedTemplates = templates.reduce(
+    (acc, template) => {
+      const category = template.category || 'その他';
+      if (!acc[category]) {
+        acc[category] = [];
+      }
+      acc[category].push(template);
+      return acc;
+    },
+    {} as Record<string, typeof templates>
+  );
+
+  return (
+    <div className="space-y-2">
+      <button
+        onClick={() => setShowTemplates(!showTemplates)}
+        className="w-full py-2 px-4 bg-purple-500 text-white rounded-lg font-medium hover:bg-purple-600 transition-colors focus:outline-none focus:ring-2 focus:ring-purple-500"
+        aria-label={showTemplates ? 'テンプレートを閉じる' : 'テンプレートを開く'}
+        aria-expanded={showTemplates}
+      >
+        {showTemplates ? '📋 テンプレートを閉じる' : '📋 テンプレート'}
+      </button>
+
+      {showTemplates && (
+        <div className="bg-white dark:bg-gray-800 rounded-lg p-4 space-y-4 border border-gray-200 dark:border-gray-700">
+          {/* テンプレート一覧 */}
+          <div className="space-y-3">
+            {Object.entries(groupedTemplates).map(([category, categoryTemplates]) => (
+              <div key={category}>
+                <h4 className="text-xs font-semibold text-gray-600 dark:text-gray-400 mb-2">
+                  {category}
+                </h4>
+                <div className="space-y-1">
+                  {categoryTemplates.map((template) => (
+                    <div
+                      key={template.id}
+                      className="flex items-center gap-2"
+                    >
+                      <button
+                        onClick={() => {
+                          onSelectTemplate(template.content);
+                          setShowTemplates(false);
+                        }}
+                        className="flex-1 text-left px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors text-sm"
+                        aria-label={`テンプレート: ${template.name}`}
+                      >
+                        <span className="font-medium text-gray-900 dark:text-gray-100">
+                          {template.name}
+                        </span>
+                        <span className="text-gray-500 dark:text-gray-400 ml-2 text-xs">
+                          {template.content.slice(0, 20)}
+                          {template.content.length > 20 && '...'}
+                        </span>
+                      </button>
+                      {!template.id.startsWith('default-') && (
+                        <button
+                          onClick={() => handleDeleteTemplate(template.id)}
+                          className="px-2 py-2 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
+                          aria-label={`${template.name}を削除`}
+                        >
+                          🗑️
+                        </button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* テンプレート追加フォーム */}
+          {showAddForm ? (
+            <div className="space-y-2 pt-3 border-t border-gray-200 dark:border-gray-700">
+              <input
+                type="text"
+                placeholder="テンプレート名"
+                value={newTemplateName}
+                onChange={(e) => setNewTemplateName(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                aria-label="テンプレート名"
+              />
+              <textarea
+                placeholder="テンプレート内容"
+                value={newTemplateContent}
+                onChange={(e) => setNewTemplateContent(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-purple-500 min-h-[60px]"
+                aria-label="テンプレート内容"
+              />
+              <input
+                type="text"
+                placeholder="カテゴリー (任意)"
+                value={newTemplateCategory}
+                onChange={(e) => setNewTemplateCategory(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                aria-label="カテゴリー"
+              />
+              <div className="flex gap-2">
+                <Button
+                  variant="primary"
+                  fullWidth
+                  onClick={handleAddTemplate}
+                  disabled={!newTemplateName.trim() || !newTemplateContent.trim()}
+                >
+                  追加
+                </Button>
+                <Button
+                  variant="outline"
+                  fullWidth
+                  onClick={() => {
+                    setShowAddForm(false);
+                    setNewTemplateName('');
+                    setNewTemplateContent('');
+                    setNewTemplateCategory('');
+                  }}
+                >
+                  キャンセル
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <button
+              onClick={() => setShowAddForm(true)}
+              className="w-full py-2 px-4 bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded font-medium hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+              aria-label="新しいテンプレートを追加"
+            >
+              ➕ 新しいテンプレートを追加
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/organisms/MessageComposer.tsx
+++ b/src/components/organisms/MessageComposer.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { MessageInput } from '../molecules/MessageInput';
+import { TemplateSelector } from '../molecules/TemplateSelector';
 import { Input } from '../atoms/Input';
 
 interface MessageComposerProps {
@@ -14,10 +15,23 @@ export const MessageComposer: React.FC<MessageComposerProps> = ({
   onSendMessage,
 }) => {
   const [senderName, setSenderName] = useState('');
+  const [receiverMessage, setReceiverMessage] = useState('');
+  const [senderMessage, setSenderMessage] = useState('');
 
   const handleSend = (content: string, isSender: boolean) => {
     onSendMessage(content, isSender, senderName || undefined);
   };
+
+  const handleSelectTemplate = useCallback(
+    (content: string, isSender: boolean) => {
+      if (isSender) {
+        setSenderMessage(content);
+      } else {
+        setReceiverMessage(content);
+      }
+    },
+    []
+  );
 
   return (
     <div className="bg-white dark:bg-gray-800 p-4 rounded-lg space-y-4">
@@ -30,13 +44,38 @@ export const MessageComposer: React.FC<MessageComposerProps> = ({
         />
       </div>
 
+      {/* テンプレートセレクター */}
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+            受信用テンプレート
+          </label>
+          <TemplateSelector
+            onSelectTemplate={(content) => handleSelectTemplate(content, false)}
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+            送信用テンプレート
+          </label>
+          <TemplateSelector
+            onSelectTemplate={(content) => handleSelectTemplate(content, true)}
+          />
+        </div>
+      </div>
+
       <div className="space-y-2">
         <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
           受信メッセージを追加
         </label>
         <MessageInput
-          onSend={(content) => handleSend(content, false)}
+          onSend={(content) => {
+            handleSend(content, false);
+            setReceiverMessage('');
+          }}
           placeholder="相手のメッセージを入力..."
+          value={receiverMessage}
+          onChange={setReceiverMessage}
         />
       </div>
 
@@ -45,8 +84,13 @@ export const MessageComposer: React.FC<MessageComposerProps> = ({
           送信メッセージを追加
         </label>
         <MessageInput
-          onSend={(content) => handleSend(content, true)}
+          onSend={(content) => {
+            handleSend(content, true);
+            setSenderMessage('');
+          }}
           placeholder="自分のメッセージを入力..."
+          value={senderMessage}
+          onChange={setSenderMessage}
         />
       </div>
     </div>

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -6,3 +6,4 @@ export { useMessageStore } from './messageStore';
 export { useThemeStore } from './themeStore';
 export { useDesignStore } from './designStore';
 export { useDarkModeStore } from './darkModeStore';
+export { useTemplateStore } from './templateStore';

--- a/src/stores/templateStore.ts
+++ b/src/stores/templateStore.ts
@@ -1,0 +1,88 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { MessageTemplate } from '../types';
+
+interface TemplateState {
+  templates: MessageTemplate[];
+  addTemplate: (name: string, content: string, category?: string) => void;
+  updateTemplate: (id: string, updates: Partial<MessageTemplate>) => void;
+  deleteTemplate: (id: string) => void;
+  getTemplate: (id: string) => MessageTemplate | undefined;
+  getTemplatesByCategory: (category: string) => MessageTemplate[];
+}
+
+/**
+ * メッセージテンプレートストア
+ * よく使うメッセージの保存・再利用を管理
+ */
+export const useTemplateStore = create<TemplateState>()(
+  persist(
+    (set, get) => ({
+      templates: [
+        // デフォルトテンプレート
+        {
+          id: 'default-1',
+          name: '挨拶',
+          content: 'お疲れ様です！',
+          category: '挨拶',
+          createdAt: new Date(),
+        },
+        {
+          id: 'default-2',
+          name: '了解',
+          content: '了解しました👍',
+          category: '返信',
+          createdAt: new Date(),
+        },
+        {
+          id: 'default-3',
+          name: 'ありがとう',
+          content: 'ありがとうございます！',
+          category: '返信',
+          createdAt: new Date(),
+        },
+      ],
+
+      addTemplate: (name, content, category) => {
+        const newTemplate: MessageTemplate = {
+          id: crypto.randomUUID(),
+          name,
+          content,
+          category,
+          createdAt: new Date(),
+        };
+
+        set((state) => ({
+          templates: [...state.templates, newTemplate],
+        }));
+      },
+
+      updateTemplate: (id, updates) => {
+        set((state) => ({
+          templates: state.templates.map((template) =>
+            template.id === id ? { ...template, ...updates } : template
+          ),
+        }));
+      },
+
+      deleteTemplate: (id) => {
+        set((state) => ({
+          templates: state.templates.filter((template) => template.id !== id),
+        }));
+      },
+
+      getTemplate: (id) => {
+        return get().templates.find((template) => template.id === id);
+      },
+
+      getTemplatesByCategory: (category) => {
+        return get().templates.filter(
+          (template) => template.category === category
+        );
+      },
+    }),
+    {
+      name: 'template-storage',
+    }
+  )
+);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,3 +25,5 @@ export type {
   ExportOptions,
   ExportResult,
 } from './export';
+
+export type { MessageTemplate, MessageTemplateJSON } from './template';

--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -1,0 +1,19 @@
+/**
+ * メッセージテンプレート関連の型定義
+ */
+
+export interface MessageTemplate {
+  id: string;
+  name: string;
+  content: string;
+  category?: string;
+  createdAt: Date;
+}
+
+export interface MessageTemplateJSON {
+  id: string;
+  name: string;
+  content: string;
+  category?: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Phase 18: メッセージテンプレート

### 型定義追加
- MessageTemplate型定義
- MessageTemplateJSON型定義
- types/template.tsを作成

### templateStore作成
- Zustand + persistミドルウェア
- テンプレートCRUD操作:
  - addTemplate: 新規テンプレート追加
  - updateTemplate: テンプレート更新
  - deleteTemplate: テンプレート削除
  - getTemplate: ID指定取得
  - getTemplatesByCategory: カテゴリー別取得
- デフォルトテンプレート3件 (挨拶、了解、ありがとう)
- LocalStorage永続化

### TemplateSelectorコンポーネント
- カテゴリー別グループ表示
- テンプレート選択UI
- テンプレート追加フォーム
- テンプレート削除機能
- デフォルトテンプレート削除禁止
- 折りたたみ式UI

### MessageInput改善
- 制御/非制御コンポーネント両対応
- value/onChangeプロパティ追加
- 後方互換性維持

### MessageComposer統合
- 受信/送信用テンプレートセレクター追加
- テンプレート選択→入力欄に自動反映
- グリッドレイアウトで2列配置

## 機能詳細
- カテゴリー分類: 挨拶、返信、その他
- テンプレート追加: 名前、内容、カテゴリー
- 即座に適用: テンプレート選択で入力欄に反映
- 永続化: LocalStorageで保存

ビルドサイズ: 431KB (gzip: 120KB)
型チェック・ビルド成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)