### PR TITLE
feat: Phase 19 マルチルーム管理機能実装

### DIFF
--- a/src/components/molecules/RoomSelector.tsx
+++ b/src/components/molecules/RoomSelector.tsx
@@ -1,0 +1,147 @@
+import React, { useState } from 'react';
+import type { ChatRoom } from '../../types';
+import { Button } from '../atoms/Button';
+import { Input } from '../atoms/Input';
+
+interface RoomSelectorProps {
+  rooms: ChatRoom[];
+  currentRoomId: string | null;
+  onSelectRoom: (roomId: string) => void;
+  onCreateRoom: (roomName: string) => void;
+  onDeleteRoom: (roomId: string) => void;
+}
+
+export const RoomSelector: React.FC<RoomSelectorProps> = ({
+  rooms,
+  currentRoomId,
+  onSelectRoom,
+  onCreateRoom,
+  onDeleteRoom,
+}) => {
+  const [showRooms, setShowRooms] = useState(false);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [newRoomName, setNewRoomName] = useState('');
+
+  const handleCreateRoom = () => {
+    if (newRoomName.trim()) {
+      onCreateRoom(newRoomName.trim());
+      setNewRoomName('');
+      setShowCreateForm(false);
+    }
+  };
+
+  const handleDeleteRoom = (roomId: string) => {
+    if (confirm('このルームを削除しますか？')) {
+      onDeleteRoom(roomId);
+    }
+  };
+
+  const currentRoom = rooms.find((room) => room.id === currentRoomId);
+
+  return (
+    <div className="space-y-2">
+      <button
+        onClick={() => setShowRooms(!showRooms)}
+        className="w-full py-2 px-4 bg-blue-500 text-white rounded-lg font-medium hover:bg-blue-600 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
+        aria-label={showRooms ? 'ルーム一覧を閉じる' : 'ルーム一覧を開く'}
+        aria-expanded={showRooms}
+      >
+        {showRooms ? '💬 ルーム一覧を閉じる' : `💬 ${currentRoom?.name || 'ルームを選択'}`}
+      </button>
+
+      {showRooms && (
+        <div className="bg-white dark:bg-gray-800 rounded-lg p-4 space-y-3 border border-gray-200 dark:border-gray-700">
+          {/* ルーム一覧 */}
+          <div className="space-y-2">
+            <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+              ルーム一覧 ({rooms.length})
+            </h4>
+            <div className="space-y-1 max-h-60 overflow-y-auto">
+              {rooms.map((room) => (
+                <div
+                  key={room.id}
+                  className="flex items-center gap-2"
+                >
+                  <button
+                    onClick={() => {
+                      onSelectRoom(room.id);
+                      setShowRooms(false);
+                    }}
+                    className={`flex-1 text-left px-3 py-2 rounded transition-colors ${
+                      room.id === currentRoomId
+                        ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-900 dark:text-blue-100'
+                        : 'bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600'
+                    }`}
+                    aria-label={`ルーム: ${room.name}`}
+                    aria-current={room.id === currentRoomId ? 'true' : 'false'}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium text-sm">{room.name}</span>
+                      <span className="text-xs text-gray-500 dark:text-gray-400">
+                        {room.messages.length}件
+                      </span>
+                    </div>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                      {new Date(room.updatedAt).toLocaleDateString('ja-JP')}
+                    </p>
+                  </button>
+                  {rooms.length > 1 && (
+                    <button
+                      onClick={() => handleDeleteRoom(room.id)}
+                      className="px-2 py-2 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
+                      aria-label={`${room.name}を削除`}
+                      disabled={room.id === currentRoomId}
+                    >
+                      🗑️
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* 新規ルーム作成フォーム */}
+          {showCreateForm ? (
+            <div className="space-y-2 pt-3 border-t border-gray-200 dark:border-gray-700">
+              <Input
+                placeholder="ルーム名"
+                value={newRoomName}
+                onChange={(e) => setNewRoomName(e.target.value)}
+                fullWidth
+                aria-label="新しいルーム名"
+              />
+              <div className="flex gap-2">
+                <Button
+                  variant="primary"
+                  fullWidth
+                  onClick={handleCreateRoom}
+                  disabled={!newRoomName.trim()}
+                >
+                  作成
+                </Button>
+                <Button
+                  variant="outline"
+                  fullWidth
+                  onClick={() => {
+                    setShowCreateForm(false);
+                    setNewRoomName('');
+                  }}
+                >
+                  キャンセル
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <button
+              onClick={() => setShowCreateForm(true)}
+              className="w-full py-2 px-4 bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded font-medium hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+              aria-label="新しいルームを作成"
+            >
+              ➕ 新しいルームを作成
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/organisms/ControlPanel.tsx
+++ b/src/components/organisms/ControlPanel.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
-import type { SnsTheme, DesignOptions, ColorScheme } from '../../types';
+import type { SnsTheme, DesignOptions, ColorScheme, ChatRoom } from '../../types';
 import type { ThemePreset } from '../../constants/themePresets';
 import { ThemeSelector } from '../molecules/ThemeSelector';
 import { ThemePresetSelector } from '../molecules/ThemePresetSelector';
 import { CustomColorSettings } from '../molecules/CustomColorSettings';
 import { DesignControls } from '../molecules/DesignControls';
 import { DarkModeToggle } from '../molecules/DarkModeToggle';
+import { RoomSelector } from '../molecules/RoomSelector';
 import { Button } from '../atoms/Button';
 
 interface ControlPanelProps {
@@ -13,6 +14,8 @@ interface ControlPanelProps {
   designOptions: DesignOptions;
   colors: ColorScheme;
   currentPresetId: string | null;
+  rooms: ChatRoom[];
+  currentRoomId: string | null;
   onThemeChange: (theme: SnsTheme) => void;
   onPresetChange: (preset: ThemePreset) => void;
   onColorChange: (key: keyof ColorScheme, value: string) => void;
@@ -20,6 +23,9 @@ interface ControlPanelProps {
   onToggleTimestamp: (show: boolean) => void;
   onToggleSenderName: (show: boolean) => void;
   onToggleStatus: (show: boolean) => void;
+  onSelectRoom: (roomId: string) => void;
+  onCreateRoom: (roomName: string) => void;
+  onDeleteRoom: (roomId: string) => void;
   onExport: () => void;
   onClear: () => void;
   onExportJSON: () => void;
@@ -33,6 +39,8 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
   designOptions,
   colors,
   currentPresetId,
+  rooms,
+  currentRoomId,
   onThemeChange,
   onPresetChange,
   onColorChange,
@@ -40,6 +48,9 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
   onToggleTimestamp,
   onToggleSenderName,
   onToggleStatus,
+  onSelectRoom,
+  onCreateRoom,
+  onDeleteRoom,
   onExport,
   onClear,
   onExportJSON,
@@ -54,6 +65,17 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
       <h2 className="text-lg font-bold text-gray-900 dark:text-white">
         設定パネル
       </h2>
+
+      {/* ルーム管理 */}
+      <div className="space-y-4 pb-4 border-b border-gray-200 dark:border-gray-700">
+        <RoomSelector
+          rooms={rooms}
+          currentRoomId={currentRoomId}
+          onSelectRoom={onSelectRoom}
+          onCreateRoom={onCreateRoom}
+          onDeleteRoom={onDeleteRoom}
+        />
+      </div>
 
       {/* ダークモード設定 */}
       <div className="space-y-4 pb-4 border-b border-gray-200 dark:border-gray-700">

--- a/src/components/pages/MainPage.tsx
+++ b/src/components/pages/MainPage.tsx
@@ -18,11 +18,14 @@ export const MainPage: React.FC = () => {
   const chatWindowRef = useRef<HTMLDivElement>(null);
   const {
     currentRoom,
+    rooms,
     addMessage,
     updateMessage,
     deleteMessage,
     clearMessages,
     createRoom,
+    loadRoom,
+    deleteRoom,
     importRoom,
   } = useMessageStore();
   const { config, currentPresetId, setSnsTheme, applyPreset, updateColor, exportTheme, importTheme } = useThemeStore();
@@ -229,6 +232,8 @@ export const MainPage: React.FC = () => {
           designOptions={options}
           colors={config.colors}
           currentPresetId={currentPresetId}
+          rooms={rooms}
+          currentRoomId={currentRoom?.id || null}
           onThemeChange={setSnsTheme}
           onPresetChange={applyPreset}
           onColorChange={updateColor}
@@ -236,6 +241,9 @@ export const MainPage: React.FC = () => {
           onToggleTimestamp={setShowTimestamp}
           onToggleSenderName={setShowSenderName}
           onToggleStatus={setShowStatus}
+          onSelectRoom={loadRoom}
+          onCreateRoom={createRoom}
+          onDeleteRoom={deleteRoom}
           onExport={handleExport}
           onClear={handleClear}
           onExportJSON={handleExportJSON}


### PR DESCRIPTION
## Phase 19: Multi-Room Management

### RoomSelector コンポーネント
- ルーム一覧表示 (メッセージ数・更新日時)
- 現在ルームのハイライト表示
- ルーム切り替え機能 (ドロップダウン自動クローズ)
- ルーム削除機能 (現在ルームは削除不可、最低1ルーム維持)
- 新規ルーム作成フォーム (折りたたみ式UI)
- ARIA対応 (aria-label, aria-expanded, aria-current)

### ControlPanel 統合
- RoomSelector をパネル最上部に配置
- room 関連 props 追加:
  - rooms: ChatRoom[]
  - currentRoomId: string | null
  - onSelectRoom, onCreateRoom, onDeleteRoom

### MainPage 統合
- messageStore から rooms, loadRoom, deleteRoom 取得
- ControlPanel に room 管理メソッドを接続
- ルーム切り替えによるメッセージ表示の動的更新

## 技術詳細
- 既存 messageStore インフラ活用
- ルームごとの状態分離
- LocalStorage 永続化対応済み
- 削除時の確認ダイアログ

型チェック・ビルド成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)