### PR TITLE
feat: Phase 20 メッセージ検索・ハイライト機能実装

### DIFF
--- a/src/components/molecules/MessageBubble.tsx
+++ b/src/components/molecules/MessageBubble.tsx
@@ -10,6 +10,8 @@ interface MessageBubbleProps {
   showSenderName?: boolean;
   showStatus?: boolean;
   bubbleColor?: string;
+  isHighlighted?: boolean;
+  isCurrentHighlight?: boolean;
   onEdit?: (id: string, content: string) => void;
   onDelete?: (id: string) => void;
 }
@@ -22,6 +24,8 @@ export const MessageBubble: React.FC<MessageBubbleProps> = React.memo(
     showSenderName = true,
     showStatus = true,
     bubbleColor,
+    isHighlighted = false,
+    isCurrentHighlight = false,
     onEdit,
     onDelete,
   }) => {
@@ -137,6 +141,9 @@ export const MessageBubble: React.FC<MessageBubbleProps> = React.memo(
               ${bubbleStyle.textColor}
               px-4 py-2 rounded-2xl
               break-words
+              ${isHighlighted ? 'ring-2 ring-yellow-400 dark:ring-yellow-500' : ''}
+              ${isCurrentHighlight ? 'ring-4 ring-orange-500 dark:ring-orange-400' : ''}
+              transition-all
             `}
           >
             {message.content}

--- a/src/components/molecules/MessageSearch.tsx
+++ b/src/components/molecules/MessageSearch.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect } from 'react';
+import { useSearchStore } from '../../stores';
+import { useMessageStore } from '../../stores';
+import { Input } from '../atoms/Input';
+import { Button } from '../atoms/Button';
+
+export const MessageSearch: React.FC = () => {
+  const {
+    searchQuery,
+    isSearchActive,
+    highlightedMessageIds,
+    currentHighlightIndex,
+    setSearchQuery,
+    setIsSearchActive,
+    setHighlightedMessageIds,
+    clearSearch,
+    nextHighlight,
+    prevHighlight,
+  } = useSearchStore();
+
+  const { currentRoom } = useMessageStore();
+
+  // 検索クエリが変更されたときにメッセージを検索
+  useEffect(() => {
+    if (!currentRoom || searchQuery.trim() === '') {
+      setHighlightedMessageIds([]);
+      return;
+    }
+
+    const query = searchQuery.toLowerCase();
+    const matchedIds = currentRoom.messages
+      .filter((message) => message.content.toLowerCase().includes(query))
+      .map((message) => message.id);
+
+    setHighlightedMessageIds(matchedIds);
+  }, [searchQuery, currentRoom, setHighlightedMessageIds]);
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value);
+    if (e.target.value.trim() !== '' && !isSearchActive) {
+      setIsSearchActive(true);
+    }
+  };
+
+  const handleClearSearch = () => {
+    clearSearch();
+  };
+
+  const resultCount = highlightedMessageIds.length;
+  const currentPosition = currentHighlightIndex >= 0 ? currentHighlightIndex + 1 : 0;
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">
+        メッセージ検索
+      </h3>
+
+      <div className="space-y-2">
+        <Input
+          placeholder="検索ワード"
+          value={searchQuery}
+          onChange={handleSearchChange}
+          fullWidth
+          aria-label="メッセージ検索"
+        />
+
+        {isSearchActive && (
+          <div className="flex items-center justify-between text-sm text-gray-600 dark:text-gray-400">
+            <span>
+              {resultCount > 0
+                ? `${currentPosition} / ${resultCount} 件`
+                : '0 件'}
+            </span>
+
+            {resultCount > 0 && (
+              <div className="flex gap-1">
+                <button
+                  onClick={prevHighlight}
+                  className="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+                  aria-label="前の結果"
+                  disabled={resultCount === 0}
+                >
+                  ↑
+                </button>
+                <button
+                  onClick={nextHighlight}
+                  className="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+                  aria-label="次の結果"
+                  disabled={resultCount === 0}
+                >
+                  ↓
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+
+        {isSearchActive && (
+          <Button variant="outline" fullWidth onClick={handleClearSearch}>
+            検索をクリア
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/organisms/ChatWindow.tsx
+++ b/src/components/organisms/ChatWindow.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useEffect } from 'react';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 import type { Message } from '../../types';
 import { MessageBubble } from '../molecules/MessageBubble';
+import { useSearchStore } from '../../stores';
 
 interface ChatWindowProps {
   messages: Message[];
@@ -27,6 +28,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   onDeleteMessage,
 }) => {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
+  const { highlightedMessageIds, currentHighlightIndex } = useSearchStore();
 
   // 新しいメッセージが追加されたら最下部にスクロール
   useEffect(() => {
@@ -63,21 +65,29 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
         aria-label="チャットメッセージ"
         aria-atomic="false"
       >
-        {messages.map((message) => (
-          <MessageBubble
-            key={message.id}
-            message={message}
-            showAvatar={showAvatar}
-            showTimestamp={showTimestamp}
-            showSenderName={showSenderName}
-            showStatus={showStatus}
-            bubbleColor={
-              message.isSender ? senderBubbleColor : receiverBubbleColor
-            }
-            onEdit={onEditMessage}
-            onDelete={onDeleteMessage}
-          />
-        ))}
+        {messages.map((message) => {
+          const isHighlighted = highlightedMessageIds.includes(message.id);
+          const isCurrentHighlight =
+            highlightedMessageIds[currentHighlightIndex] === message.id;
+
+          return (
+            <MessageBubble
+              key={message.id}
+              message={message}
+              showAvatar={showAvatar}
+              showTimestamp={showTimestamp}
+              showSenderName={showSenderName}
+              showStatus={showStatus}
+              bubbleColor={
+                message.isSender ? senderBubbleColor : receiverBubbleColor
+              }
+              isHighlighted={isHighlighted}
+              isCurrentHighlight={isCurrentHighlight}
+              onEdit={onEditMessage}
+              onDelete={onDeleteMessage}
+            />
+          );
+        })}
       </div>
     );
   }
@@ -95,21 +105,29 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
         ref={virtuosoRef}
         style={{ height: '600px' }}
         data={messages}
-        itemContent={(_index, message) => (
-          <MessageBubble
-            key={message.id}
-            message={message}
-            showAvatar={showAvatar}
-            showTimestamp={showTimestamp}
-            showSenderName={showSenderName}
-            showStatus={showStatus}
-            bubbleColor={
-              message.isSender ? senderBubbleColor : receiverBubbleColor
-            }
-            onEdit={onEditMessage}
-            onDelete={onDeleteMessage}
-          />
-        )}
+        itemContent={(_index, message) => {
+          const isHighlighted = highlightedMessageIds.includes(message.id);
+          const isCurrentHighlight =
+            highlightedMessageIds[currentHighlightIndex] === message.id;
+
+          return (
+            <MessageBubble
+              key={message.id}
+              message={message}
+              showAvatar={showAvatar}
+              showTimestamp={showTimestamp}
+              showSenderName={showSenderName}
+              showStatus={showStatus}
+              bubbleColor={
+                message.isSender ? senderBubbleColor : receiverBubbleColor
+              }
+              isHighlighted={isHighlighted}
+              isCurrentHighlight={isCurrentHighlight}
+              onEdit={onEditMessage}
+              onDelete={onDeleteMessage}
+            />
+          );
+        }}
         followOutput="smooth"
       />
     </div>

--- a/src/components/organisms/ChatWindow.tsx
+++ b/src/components/organisms/ChatWindow.tsx
@@ -68,6 +68,8 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
         {messages.map((message) => {
           const isHighlighted = highlightedMessageIds.includes(message.id);
           const isCurrentHighlight =
+            currentHighlightIndex >= 0 &&
+            currentHighlightIndex < highlightedMessageIds.length &&
             highlightedMessageIds[currentHighlightIndex] === message.id;
 
           return (
@@ -108,6 +110,8 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
         itemContent={(_index, message) => {
           const isHighlighted = highlightedMessageIds.includes(message.id);
           const isCurrentHighlight =
+            currentHighlightIndex >= 0 &&
+            currentHighlightIndex < highlightedMessageIds.length &&
             highlightedMessageIds[currentHighlightIndex] === message.id;
 
           return (

--- a/src/components/organisms/ControlPanel.tsx
+++ b/src/components/organisms/ControlPanel.tsx
@@ -7,6 +7,7 @@ import { CustomColorSettings } from '../molecules/CustomColorSettings';
 import { DesignControls } from '../molecules/DesignControls';
 import { DarkModeToggle } from '../molecules/DarkModeToggle';
 import { RoomSelector } from '../molecules/RoomSelector';
+import { MessageSearch } from '../molecules/MessageSearch';
 import { Button } from '../atoms/Button';
 
 interface ControlPanelProps {
@@ -75,6 +76,11 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
           onCreateRoom={onCreateRoom}
           onDeleteRoom={onDeleteRoom}
         />
+      </div>
+
+      {/* メッセージ検索 */}
+      <div className="space-y-4 pb-4 border-b border-gray-200 dark:border-gray-700">
+        <MessageSearch />
       </div>
 
       {/* ダークモード設定 */}

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -7,3 +7,4 @@ export { useThemeStore } from './themeStore';
 export { useDesignStore } from './designStore';
 export { useDarkModeStore } from './darkModeStore';
 export { useTemplateStore } from './templateStore';
+export { useSearchStore } from './searchStore';

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -1,0 +1,59 @@
+import { create } from 'zustand';
+
+interface SearchState {
+  searchQuery: string;
+  isSearchActive: boolean;
+  highlightedMessageIds: string[];
+  currentHighlightIndex: number;
+  setSearchQuery: (query: string) => void;
+  setIsSearchActive: (active: boolean) => void;
+  setHighlightedMessageIds: (ids: string[]) => void;
+  setCurrentHighlightIndex: (index: number) => void;
+  clearSearch: () => void;
+  nextHighlight: () => void;
+  prevHighlight: () => void;
+}
+
+export const useSearchStore = create<SearchState>()((set, get) => ({
+  searchQuery: '',
+  isSearchActive: false,
+  highlightedMessageIds: [],
+  currentHighlightIndex: -1,
+
+  setSearchQuery: (query) => set({ searchQuery: query }),
+
+  setIsSearchActive: (active) => set({ isSearchActive: active }),
+
+  setHighlightedMessageIds: (ids) =>
+    set({
+      highlightedMessageIds: ids,
+      currentHighlightIndex: ids.length > 0 ? 0 : -1,
+    }),
+
+  setCurrentHighlightIndex: (index) => set({ currentHighlightIndex: index }),
+
+  clearSearch: () =>
+    set({
+      searchQuery: '',
+      isSearchActive: false,
+      highlightedMessageIds: [],
+      currentHighlightIndex: -1,
+    }),
+
+  nextHighlight: () => {
+    const { highlightedMessageIds, currentHighlightIndex } = get();
+    if (highlightedMessageIds.length === 0) return;
+    const nextIndex = (currentHighlightIndex + 1) % highlightedMessageIds.length;
+    set({ currentHighlightIndex: nextIndex });
+  },
+
+  prevHighlight: () => {
+    const { highlightedMessageIds, currentHighlightIndex } = get();
+    if (highlightedMessageIds.length === 0) return;
+    const prevIndex =
+      currentHighlightIndex === 0
+        ? highlightedMessageIds.length - 1
+        : currentHighlightIndex - 1;
+    set({ currentHighlightIndex: prevIndex });
+  },
+}));


### PR DESCRIPTION
## Phase 20: Message Search

### searchStore (Zustand)
- searchQuery: 検索クエリ文字列
- isSearchActive: 検索モード状態
- highlightedMessageIds: 検索結果のメッセージID配列
- currentHighlightIndex: 現在のハイライトインデックス
- nextHighlight/prevHighlight: ナビゲーション機能
- clearSearch: 検索状態のクリア

### MessageSearch コンポーネント
- リアルタイム検索 (useEffect で自動検索)
- 検索結果カウント表示 (X / Y 件)
- ↑/↓ ボタンで結果ナビゲーション
- 検索クリア機能

### ハイライト表示
- MessageBubble: isHighlighted/isCurrentHighlight props 追加
  - isHighlighted: 黄色リング (ring-2 ring-yellow-400)
  - isCurrentHighlight: オレンジリング (ring-4 ring-orange-500)
- ChatWindow: useSearchStore から状態を取得してハイライト適用
  - 通常レンダリング (<100件)
  - 仮想スクロール (>=100件)

### ControlPanel 統合
- MessageSearch をルーム管理とダークモードの間に配置

## 技術詳細
- 部分一致検索 (toLowerCase() で大文字小文字区別なし)
- リアクティブ検索 (searchQuery 変更時に自動実行)
- 仮想スクロール対応 (Virtuoso でも動作)

型チェック・ビルド成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)