### PR TITLE
feat: Phase 21 ドラッグ&ドロップでメッセージ並び替え機能実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "sns-chat-mockup-generator",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "clsx": "^2.1.1",
         "html2canvas": "^1.4.1",
         "react": "^18.3.1",
@@ -335,6 +338,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -4129,6 +4185,12 @@
       "peerDependencies": {
         "typescript": ">=4.2.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "clsx": "^2.1.1",
     "html2canvas": "^1.4.1",
     "react": "^18.3.1",

--- a/src/components/molecules/SortableMessageBubble.tsx
+++ b/src/components/molecules/SortableMessageBubble.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { Message } from '../../types';
+import { MessageBubble } from './MessageBubble';
+
+interface SortableMessageBubbleProps {
+  message: Message;
+  showAvatar?: boolean;
+  showTimestamp?: boolean;
+  showSenderName?: boolean;
+  showStatus?: boolean;
+  bubbleColor?: string;
+  isHighlighted?: boolean;
+  isCurrentHighlight?: boolean;
+  onEdit?: (id: string, content: string) => void;
+  onDelete?: (id: string) => void;
+}
+
+export const SortableMessageBubble: React.FC<SortableMessageBubbleProps> = (
+  props
+) => {
+  const { message } = props;
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: message.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    cursor: 'grab',
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      <MessageBubble {...props} />
+    </div>
+  );
+};

--- a/src/components/pages/MainPage.tsx
+++ b/src/components/pages/MainPage.tsx
@@ -23,6 +23,7 @@ export const MainPage: React.FC = () => {
     updateMessage,
     deleteMessage,
     clearMessages,
+    reorderMessages,
     createRoom,
     loadRoom,
     deleteRoom,
@@ -222,6 +223,7 @@ export const MainPage: React.FC = () => {
             receiverBubbleColor={config.colors.receiverBubble}
             onEditMessage={handleEditMessage}
             onDeleteMessage={handleDeleteMessage}
+            onReorderMessages={reorderMessages}
           />
         </div>
       }

--- a/src/stores/messageStore.ts
+++ b/src/stores/messageStore.ts
@@ -10,6 +10,7 @@ interface MessageState {
   updateMessage: (id: string, updates: Partial<Message>) => void;
   deleteMessage: (id: string) => void;
   clearMessages: () => void;
+  reorderMessages: (fromIndex: number, toIndex: number) => void;
   createRoom: (name: string) => ChatRoom;
   deleteRoom: (roomId: string) => void;
   loadRoom: (roomId: string) => void;
@@ -82,6 +83,27 @@ export const useMessageStore = create<MessageState>()(
             messages: [],
             updatedAt: new Date(),
           };
+          return {
+            currentRoom: updatedRoom,
+            rooms: state.rooms.map((room) =>
+              room.id === updatedRoom.id ? updatedRoom : room,
+            ),
+          };
+        }),
+
+      reorderMessages: (fromIndex, toIndex) =>
+        set((state) => {
+          if (!state.currentRoom) return state;
+          const messages = [...state.currentRoom.messages];
+          const [movedMessage] = messages.splice(fromIndex, 1);
+          messages.splice(toIndex, 0, movedMessage);
+
+          const updatedRoom = {
+            ...state.currentRoom,
+            messages,
+            updatedAt: new Date(),
+          };
+
           return {
             currentRoom: updatedRoom,
             rooms: state.rooms.map((room) =>


### PR DESCRIPTION
## Phase 21: Drag and Drop Message Reordering

### @dnd-kit ライブラリ統合
- @dnd-kit/core: DnDContext, sensors, collision detection
- @dnd-kit/sortable: SortableContext, vertical list strategy
- @dnd-kit/utilities: CSS transform utilities

### messageStore 拡張
- reorderMessages(fromIndex, toIndex) メソッド追加
- splice による配列の並び替え
- updatedAt 自動更新
- rooms 配列への同期

### SortableMessageBubble コンポーネント
- useSortable フック利用
- transform/transition/opacity スタイル適用
- ドラッグ中の視覚的フィードバック (opacity: 0.5)
- cursor: grab でドラッグ可能を明示

### ChatWindow 統合
- DndContext で100件未満のメッセージをラップ
- SortableContext で vertical list strategy 適用
- PointerSensor + KeyboardSensor でアクセシビリティ対応
- handleDragEnd でメッセージID→インデックス変換
- onReorderMessages prop で親コンポーネント連携

### MainPage 統合
- reorderMessages を messageStore から取得
- ChatWindow に onReorderMessages prop を渡す

## 技術詳細
- 100件未満: DnD対応
- 100件以上: 仮想スクロール (DnD非対応)
- キーボード操作対応 (sortableKeyboardCoordinates)
- 検索ハイライトとの互換性維持

型チェック・ビルド成功確認済み
ビルドサイズ: 483KB (gzip: 136KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)