### PR TITLE
feat: Phase 22 メッセージフィルタリング機能実装

### DIFF
--- a/src/components/molecules/MessageFilter.tsx
+++ b/src/components/molecules/MessageFilter.tsx
@@ -1,0 +1,166 @@
+import React, { useState } from 'react';
+import { useFilterStore, type FilterType } from '../../stores';
+import { Button } from '../atoms/Button';
+
+export const MessageFilter: React.FC = () => {
+  const { filterType, dateRange, setFilterType, setDateRange, clearFilter } =
+    useFilterStore();
+
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+
+  const handleFilterChange = (type: FilterType) => {
+    setFilterType(type);
+  };
+
+  const handleDateRangeApply = () => {
+    const start = startDate ? new Date(startDate) : null;
+    const end = endDate ? new Date(endDate) : null;
+    setDateRange(start, end);
+  };
+
+  const handleClearFilter = () => {
+    clearFilter();
+    setStartDate('');
+    setEndDate('');
+  };
+
+  const activeCount =
+    filterType === 'all'
+      ? 0
+      : filterType === 'date' && (dateRange.start || dateRange.end)
+        ? 1
+        : 1;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">
+          メッセージフィルター
+        </h3>
+        {activeCount > 0 && (
+          <span className="text-xs bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-2 py-1 rounded-full">
+            {activeCount} 個適用中
+          </span>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex flex-col gap-2">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name="filter-type"
+              value="all"
+              checked={filterType === 'all'}
+              onChange={() => handleFilterChange('all')}
+              className="w-4 h-4 text-blue-600 focus:ring-2 focus:ring-blue-500"
+              aria-label="すべて表示"
+            />
+            <span className="text-sm text-gray-700 dark:text-gray-300">
+              すべて表示
+            </span>
+          </label>
+
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name="filter-type"
+              value="sent"
+              checked={filterType === 'sent'}
+              onChange={() => handleFilterChange('sent')}
+              className="w-4 h-4 text-blue-600 focus:ring-2 focus:ring-blue-500"
+              aria-label="送信メッセージのみ"
+            />
+            <span className="text-sm text-gray-700 dark:text-gray-300">
+              送信メッセージのみ
+            </span>
+          </label>
+
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name="filter-type"
+              value="received"
+              checked={filterType === 'received'}
+              onChange={() => handleFilterChange('received')}
+              className="w-4 h-4 text-blue-600 focus:ring-2 focus:ring-blue-500"
+              aria-label="受信メッセージのみ"
+            />
+            <span className="text-sm text-gray-700 dark:text-gray-300">
+              受信メッセージのみ
+            </span>
+          </label>
+
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name="filter-type"
+              value="date"
+              checked={filterType === 'date'}
+              onChange={() => handleFilterChange('date')}
+              className="w-4 h-4 text-blue-600 focus:ring-2 focus:ring-blue-500"
+              aria-label="日付範囲指定"
+            />
+            <span className="text-sm text-gray-700 dark:text-gray-300">
+              日付範囲指定
+            </span>
+          </label>
+        </div>
+
+        {filterType === 'date' && (
+          <div className="space-y-2 pl-6 pt-2">
+            <div className="space-y-1">
+              <label
+                htmlFor="filter-start-date"
+                className="text-xs text-gray-600 dark:text-gray-400"
+              >
+                開始日
+              </label>
+              <input
+                id="filter-start-date"
+                type="date"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                aria-label="開始日"
+              />
+            </div>
+
+            <div className="space-y-1">
+              <label
+                htmlFor="filter-end-date"
+                className="text-xs text-gray-600 dark:text-gray-400"
+              >
+                終了日
+              </label>
+              <input
+                id="filter-end-date"
+                type="date"
+                value={endDate}
+                onChange={(e) => setEndDate(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                aria-label="終了日"
+              />
+            </div>
+
+            <Button
+              variant="primary"
+              fullWidth
+              onClick={handleDateRangeApply}
+              disabled={!startDate && !endDate}
+            >
+              日付範囲を適用
+            </Button>
+          </div>
+        )}
+
+        {activeCount > 0 && (
+          <Button variant="outline" fullWidth onClick={handleClearFilter}>
+            フィルターをクリア
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/organisms/ControlPanel.tsx
+++ b/src/components/organisms/ControlPanel.tsx
@@ -8,6 +8,7 @@ import { DesignControls } from '../molecules/DesignControls';
 import { DarkModeToggle } from '../molecules/DarkModeToggle';
 import { RoomSelector } from '../molecules/RoomSelector';
 import { MessageSearch } from '../molecules/MessageSearch';
+import { MessageFilter } from '../molecules/MessageFilter';
 import { Button } from '../atoms/Button';
 
 interface ControlPanelProps {
@@ -81,6 +82,11 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
       {/* メッセージ検索 */}
       <div className="space-y-4 pb-4 border-b border-gray-200 dark:border-gray-700">
         <MessageSearch />
+      </div>
+
+      {/* メッセージフィルター */}
+      <div className="space-y-4 pb-4 border-b border-gray-200 dark:border-gray-700">
+        <MessageFilter />
       </div>
 
       {/* ダークモード設定 */}

--- a/src/components/pages/MainPage.tsx
+++ b/src/components/pages/MainPage.tsx
@@ -1,7 +1,8 @@
-import React, { useCallback, useRef, useEffect } from 'react';
+import React, { useCallback, useRef, useEffect, useMemo } from 'react';
 import type { Message, ChatRoomJSON } from '../../types';
-import { useMessageStore, useThemeStore, useDesignStore } from '../../stores';
+import { useMessageStore, useThemeStore, useDesignStore, useFilterStore } from '../../stores';
 import { useKeyboardShortcuts } from '../../hooks';
+import { filterMessages } from '../../utils/filterMessages';
 import {
   exportChatAsImage,
   exportChatAsJSON,
@@ -37,6 +38,14 @@ export const MainPage: React.FC = () => {
     setShowSenderName,
     setShowStatus,
   } = useDesignStore();
+
+  const { filterType, dateRange } = useFilterStore();
+
+  // フィルター適用済みメッセージ
+  const filteredMessages = useMemo(() => {
+    if (!currentRoom) return [];
+    return filterMessages(currentRoom.messages, filterType, dateRange);
+  }, [currentRoom, filterType, dateRange]);
 
   // 初期化: currentRoomがnullの場合、デフォルトルームを作成
   useEffect(() => {
@@ -214,7 +223,7 @@ export const MainPage: React.FC = () => {
       chatWindow={
         <div ref={chatWindowRef}>
           <ChatWindow
-            messages={currentRoom?.messages || []}
+            messages={filteredMessages}
             showAvatar={options.showAvatar}
             showTimestamp={options.showTimestamp}
             showSenderName={options.showSenderName}

--- a/src/stores/filterStore.ts
+++ b/src/stores/filterStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 
 export type FilterType = 'all' | 'sent' | 'received' | 'date';
 
-interface DateRange {
+export interface DateRange {
   start: Date | null;
   end: Date | null;
 }

--- a/src/stores/filterStore.ts
+++ b/src/stores/filterStore.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand';
+
+export type FilterType = 'all' | 'sent' | 'received' | 'date';
+
+interface DateRange {
+  start: Date | null;
+  end: Date | null;
+}
+
+interface FilterState {
+  filterType: FilterType;
+  dateRange: DateRange;
+  setFilterType: (type: FilterType) => void;
+  setDateRange: (start: Date | null, end: Date | null) => void;
+  clearFilter: () => void;
+}
+
+export const useFilterStore = create<FilterState>()((set) => ({
+  filterType: 'all',
+  dateRange: {
+    start: null,
+    end: null,
+  },
+
+  setFilterType: (type) => set({ filterType: type }),
+
+  setDateRange: (start, end) =>
+    set({
+      dateRange: { start, end },
+      filterType: 'date',
+    }),
+
+  clearFilter: () =>
+    set({
+      filterType: 'all',
+      dateRange: { start: null, end: null },
+    }),
+}));

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -8,3 +8,5 @@ export { useDesignStore } from './designStore';
 export { useDarkModeStore } from './darkModeStore';
 export { useTemplateStore } from './templateStore';
 export { useSearchStore } from './searchStore';
+export { useFilterStore } from './filterStore';
+export type { FilterType } from './filterStore';

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -9,4 +9,4 @@ export { useDarkModeStore } from './darkModeStore';
 export { useTemplateStore } from './templateStore';
 export { useSearchStore } from './searchStore';
 export { useFilterStore } from './filterStore';
-export type { FilterType } from './filterStore';
+export type { FilterType, DateRange } from './filterStore';

--- a/src/utils/filterMessages.ts
+++ b/src/utils/filterMessages.ts
@@ -1,0 +1,57 @@
+import type { Message } from '../types';
+import type { FilterType } from '../stores';
+
+interface DateRange {
+  start: Date | null;
+  end: Date | null;
+}
+
+export const filterMessages = (
+  messages: Message[],
+  filterType: FilterType,
+  dateRange: DateRange
+): Message[] => {
+  if (filterType === 'all') {
+    return messages;
+  }
+
+  if (filterType === 'sent') {
+    return messages.filter((msg) => msg.isSender);
+  }
+
+  if (filterType === 'received') {
+    return messages.filter((msg) => !msg.isSender);
+  }
+
+  if (filterType === 'date') {
+    const { start, end } = dateRange;
+
+    return messages.filter((msg) => {
+      const messageDate = new Date(msg.timestamp);
+
+      if (start && end) {
+        const startDate = new Date(start);
+        startDate.setHours(0, 0, 0, 0);
+        const endDate = new Date(end);
+        endDate.setHours(23, 59, 59, 999);
+        return messageDate >= startDate && messageDate <= endDate;
+      }
+
+      if (start) {
+        const startDate = new Date(start);
+        startDate.setHours(0, 0, 0, 0);
+        return messageDate >= startDate;
+      }
+
+      if (end) {
+        const endDate = new Date(end);
+        endDate.setHours(23, 59, 59, 999);
+        return messageDate <= endDate;
+      }
+
+      return true;
+    });
+  }
+
+  return messages;
+};

--- a/src/utils/filterMessages.ts
+++ b/src/utils/filterMessages.ts
@@ -1,10 +1,5 @@
 import type { Message } from '../types';
-import type { FilterType } from '../stores';
-
-interface DateRange {
-  start: Date | null;
-  end: Date | null;
-}
+import type { FilterType, DateRange } from '../stores';
 
 export const filterMessages = (
   messages: Message[],


### PR DESCRIPTION
## Phase 22: Message Filtering

### filterStore (Zustand)
- filterType: 'all' | 'sent' | 'received' | 'date'
- dateRange: { start, end } for date range filtering
- setFilterType, setDateRange, clearFilter アクション

### MessageFilter コンポーネント
- ラジオボタンでフィルタータイプ選択
- 日付範囲指定 (開始日・終了日)
- アクティブフィルター数のバッジ表示
- フィルタークリアボタン

### filterMessages ユーティリティ関数
- 送信/受信メッセージのフィルタリング
- 日付範囲によるフィルタリング
  - 開始日のみ: 00:00:00 から
  - 終了日のみ: 23:59:59 まで
  - 両方指定: 範囲内のメッセージ

### MainPage 統合
- useFilterStore からフィルター状態を取得
- useMemo で filteredMessages を計算
- ChatWindow に filteredMessages を渡す

### ControlPanel 統合
- MessageFilter を検索とダークモードの間に配置

## 技術詳細
- フィルター適用時の自動再計算 (useMemo)
- 日付の時刻部分を適切に処理 (00:00:00 ~ 23:59:59)
- アクティブフィルター数の視覚的フィードバック
- 既存機能との互換性維持

型チェック・ビルド成功確認済み
ビルドサイズ: 487KB (gzip: 137KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)