### PR TITLE
feat: Phase 23 メッセージソート機能実装

### DIFF
--- a/src/components/molecules/MessageSort.tsx
+++ b/src/components/molecules/MessageSort.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { useSortStore } from '../../stores';
+import type { SortType } from '../../stores';
+
+export const MessageSort: React.FC = () => {
+  const { sortType, setSortType } = useSortStore();
+
+  const handleSortChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setSortType(event.target.value as SortType);
+  };
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+        メッセージソート
+      </h3>
+
+      <div className="space-y-2">
+        <label className="text-xs text-gray-600 dark:text-gray-400">
+          並び順
+        </label>
+        <select
+          value={sortType}
+          onChange={handleSortChange}
+          className="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        >
+          <option value="newest">新しい順</option>
+          <option value="oldest">古い順</option>
+          <option value="sender-first">送信者優先</option>
+          <option value="receiver-first">受信者優先</option>
+        </select>
+      </div>
+
+      {sortType !== 'newest' && (
+        <div className="flex items-center gap-2 mt-2">
+          <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+            ソート中: {getSortLabel(sortType)}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const getSortLabel = (sortType: SortType): string => {
+  switch (sortType) {
+    case 'newest':
+      return '新しい順';
+    case 'oldest':
+      return '古い順';
+    case 'sender-first':
+      return '送信者優先';
+    case 'receiver-first':
+      return '受信者優先';
+    default:
+      return '';
+  }
+};

--- a/src/components/organisms/ControlPanel.tsx
+++ b/src/components/organisms/ControlPanel.tsx
@@ -9,6 +9,7 @@ import { DarkModeToggle } from '../molecules/DarkModeToggle';
 import { RoomSelector } from '../molecules/RoomSelector';
 import { MessageSearch } from '../molecules/MessageSearch';
 import { MessageFilter } from '../molecules/MessageFilter';
+import { MessageSort } from '../molecules/MessageSort';
 import { Button } from '../atoms/Button';
 
 interface ControlPanelProps {
@@ -87,6 +88,11 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
       {/* メッセージフィルター */}
       <div className="space-y-4 pb-4 border-b border-gray-200 dark:border-gray-700">
         <MessageFilter />
+      </div>
+
+      {/* メッセージソート */}
+      <div className="space-y-4 pb-4 border-b border-gray-200 dark:border-gray-700">
+        <MessageSort />
       </div>
 
       {/* ダークモード設定 */}

--- a/src/components/pages/MainPage.tsx
+++ b/src/components/pages/MainPage.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useRef, useEffect, useMemo } from 'react';
 import type { Message, ChatRoomJSON } from '../../types';
-import { useMessageStore, useThemeStore, useDesignStore, useFilterStore } from '../../stores';
+import { useMessageStore, useThemeStore, useDesignStore, useFilterStore, useSortStore } from '../../stores';
 import { useKeyboardShortcuts } from '../../hooks';
 import { filterMessages } from '../../utils/filterMessages';
+import { sortMessages } from '../../utils/sortMessages';
 import {
   exportChatAsImage,
   exportChatAsJSON,
@@ -40,12 +41,14 @@ export const MainPage: React.FC = () => {
   } = useDesignStore();
 
   const { filterType, dateRange } = useFilterStore();
+  const { sortType } = useSortStore();
 
-  // フィルター適用済みメッセージ
-  const filteredMessages = useMemo(() => {
+  // フィルター・ソート適用済みメッセージ
+  const filteredAndSortedMessages = useMemo(() => {
     if (!currentRoom) return [];
-    return filterMessages(currentRoom.messages, filterType, dateRange);
-  }, [currentRoom, filterType, dateRange]);
+    const filtered = filterMessages(currentRoom.messages, filterType, dateRange);
+    return sortMessages(filtered, sortType);
+  }, [currentRoom, filterType, dateRange, sortType]);
 
   // 初期化: currentRoomがnullの場合、デフォルトルームを作成
   useEffect(() => {
@@ -223,7 +226,7 @@ export const MainPage: React.FC = () => {
       chatWindow={
         <div ref={chatWindowRef}>
           <ChatWindow
-            messages={filteredMessages}
+            messages={filteredAndSortedMessages}
             showAvatar={options.showAvatar}
             showTimestamp={options.showTimestamp}
             showSenderName={options.showSenderName}

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -9,4 +9,6 @@ export { useDarkModeStore } from './darkModeStore';
 export { useTemplateStore } from './templateStore';
 export { useSearchStore } from './searchStore';
 export { useFilterStore } from './filterStore';
+export { useSortStore } from './sortStore';
 export type { FilterType, DateRange } from './filterStore';
+export type { SortType } from './sortStore';

--- a/src/stores/sortStore.ts
+++ b/src/stores/sortStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+export type SortType = 'newest' | 'oldest' | 'sender-first' | 'receiver-first';
+
+interface SortState {
+  sortType: SortType;
+  setSortType: (type: SortType) => void;
+}
+
+export const useSortStore = create<SortState>()((set) => ({
+  sortType: 'newest',
+  setSortType: (type) => set({ sortType: type }),
+}));

--- a/src/utils/sortMessages.ts
+++ b/src/utils/sortMessages.ts
@@ -1,0 +1,46 @@
+import type { Message } from '../types';
+import type { SortType } from '../stores';
+
+export const sortMessages = (
+  messages: Message[],
+  sortType: SortType
+): Message[] => {
+  const sorted = [...messages];
+
+  switch (sortType) {
+    case 'newest':
+      return sorted.sort(
+        (a, b) =>
+          new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+      );
+
+    case 'oldest':
+      return sorted.sort(
+        (a, b) =>
+          new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+      );
+
+    case 'sender-first':
+      return sorted.sort((a, b) => {
+        if (a.isSender === b.isSender) {
+          return (
+            new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+          );
+        }
+        return a.isSender ? -1 : 1;
+      });
+
+    case 'receiver-first':
+      return sorted.sort((a, b) => {
+        if (a.isSender === b.isSender) {
+          return (
+            new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+          );
+        }
+        return a.isSender ? 1 : -1;
+      });
+
+    default:
+      return sorted;
+  }
+};


### PR DESCRIPTION
## Phase 23: メッセージソート
- sortStoreとSortType作成 ('newest' | 'oldest' | 'sender-first' | 'receiver-first')
- sortMessages関数を実装 (4種類のソートロジック)
  - newest: 新しい順 (タイムスタンプ降順)
  - oldest: 古い順 (タイムスタンプ昇順)
  - sender-first: 送信者優先 (送信メッセージを先に表示、時系列順)
  - receiver-first: 受信者優先 (受信メッセージを先に表示、時系列順)
- MessageSortコンポーネント作成 (selectドロップダウンUI)
- ControlPanelにMessageSortを統合 (MessageFilterの下に配置)
- MainPageでソート機能を適用 (useMemoで最適化)

## 技術詳細
- Zustandストアで状態管理
- useMemoでフィルター→ソートの順に適用
- アクティブソート表示バッジ (デフォルトの'newest'以外)
- セカンダリソート: sender/receiver-firstでは同一グループ内を時系列順

ビルド: 489.43 kB (gzip: 137.12 kB)
型チェック・ビルド成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)