### PR TITLE
feat: Phase 25 メッセージ統計機能実装

### DIFF
--- a/src/components/molecules/MessageStatistics.tsx
+++ b/src/components/molecules/MessageStatistics.tsx
@@ -1,0 +1,199 @@
+import React, { useMemo } from 'react';
+import { useMessageStore } from '../../stores';
+import { calculateMessageStatistics } from '../../utils/calculateMessageStatistics';
+
+export const MessageStatistics: React.FC = () => {
+  const { currentRoom } = useMessageStore();
+
+  const statistics = useMemo(() => {
+    if (!currentRoom) {
+      return null;
+    }
+    return calculateMessageStatistics(currentRoom.messages);
+  }, [currentRoom]);
+
+  if (!statistics || statistics.totalMessages === 0) {
+    return (
+      <div className="space-y-3">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+          メッセージ統計
+        </h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          メッセージがありません
+        </p>
+      </div>
+    );
+  }
+
+  const mostActiveDay = Object.entries(statistics.messagesPerDay).sort(
+    ([, a], [, b]) => b - a
+  )[0];
+
+  const mostActiveHour = Object.entries(statistics.messagesPerHour).sort(
+    ([, a], [, b]) => b - a
+  )[0];
+
+  const formatDate = (date: Date | null) => {
+    if (!date) return '-';
+    return new Intl.DateTimeFormat('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(date);
+  };
+
+  const daysDiff =
+    statistics.firstMessageDate && statistics.lastMessageDate
+      ? Math.ceil(
+          (statistics.lastMessageDate.getTime() -
+            statistics.firstMessageDate.getTime()) /
+            (1000 * 60 * 60 * 24)
+        )
+      : 0;
+
+  const messagesPerDayAverage =
+    daysDiff > 0 ? (statistics.totalMessages / daysDiff).toFixed(1) : '0';
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+        メッセージ統計
+      </h3>
+
+      <div className="space-y-2 text-sm">
+        {/* 基本統計 */}
+        <div className="grid grid-cols-2 gap-2">
+          <div className="p-2 bg-white dark:bg-gray-700 rounded">
+            <div className="text-xs text-gray-500 dark:text-gray-400">
+              総メッセージ数
+            </div>
+            <div className="text-lg font-bold text-gray-900 dark:text-white">
+              {statistics.totalMessages}
+            </div>
+          </div>
+          <div className="p-2 bg-white dark:bg-gray-700 rounded">
+            <div className="text-xs text-gray-500 dark:text-gray-400">
+              1日平均
+            </div>
+            <div className="text-lg font-bold text-gray-900 dark:text-white">
+              {messagesPerDayAverage}
+            </div>
+          </div>
+        </div>
+
+        {/* 送受信統計 */}
+        <div className="grid grid-cols-2 gap-2">
+          <div className="p-2 bg-blue-50 dark:bg-blue-900/20 rounded">
+            <div className="text-xs text-blue-600 dark:text-blue-400">
+              送信メッセージ
+            </div>
+            <div className="text-lg font-bold text-blue-700 dark:text-blue-300">
+              {statistics.sentMessages}
+            </div>
+          </div>
+          <div className="p-2 bg-green-50 dark:bg-green-900/20 rounded">
+            <div className="text-xs text-green-600 dark:text-green-400">
+              受信メッセージ
+            </div>
+            <div className="text-lg font-bold text-green-700 dark:text-green-300">
+              {statistics.receivedMessages}
+            </div>
+          </div>
+        </div>
+
+        {/* メッセージ長統計 */}
+        <div className="p-2 bg-gray-50 dark:bg-gray-700 rounded space-y-1">
+          <div className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+            メッセージ長
+          </div>
+          <div className="grid grid-cols-3 gap-2 text-xs">
+            <div>
+              <span className="text-gray-500 dark:text-gray-400">平均: </span>
+              <span className="font-medium text-gray-900 dark:text-white">
+                {statistics.averageMessageLength}文字
+              </span>
+            </div>
+            <div>
+              <span className="text-gray-500 dark:text-gray-400">最長: </span>
+              <span className="font-medium text-gray-900 dark:text-white">
+                {statistics.longestMessage}文字
+              </span>
+            </div>
+            <div>
+              <span className="text-gray-500 dark:text-gray-400">最短: </span>
+              <span className="font-medium text-gray-900 dark:text-white">
+                {statistics.shortestMessage}文字
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* アクティビティ統計 */}
+        <div className="p-2 bg-gray-50 dark:bg-gray-700 rounded space-y-1">
+          <div className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+            アクティビティ
+          </div>
+          <div className="space-y-1 text-xs">
+            {mostActiveDay && (
+              <div>
+                <span className="text-gray-500 dark:text-gray-400">
+                  最多の日:{' '}
+                </span>
+                <span className="font-medium text-gray-900 dark:text-white">
+                  {mostActiveDay[0]} ({mostActiveDay[1]}件)
+                </span>
+              </div>
+            )}
+            {mostActiveHour && (
+              <div>
+                <span className="text-gray-500 dark:text-gray-400">
+                  最多の時間帯:{' '}
+                </span>
+                <span className="font-medium text-gray-900 dark:text-white">
+                  {mostActiveHour[0]}時台 ({mostActiveHour[1]}件)
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* 期間統計 */}
+        <div className="p-2 bg-gray-50 dark:bg-gray-700 rounded space-y-1">
+          <div className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+            期間
+          </div>
+          <div className="space-y-1 text-xs">
+            <div>
+              <span className="text-gray-500 dark:text-gray-400">
+                最初のメッセージ:{' '}
+              </span>
+              <span className="font-medium text-gray-900 dark:text-white">
+                {formatDate(statistics.firstMessageDate)}
+              </span>
+            </div>
+            <div>
+              <span className="text-gray-500 dark:text-gray-400">
+                最後のメッセージ:{' '}
+              </span>
+              <span className="font-medium text-gray-900 dark:text-white">
+                {formatDate(statistics.lastMessageDate)}
+              </span>
+            </div>
+            {daysDiff > 0 && (
+              <div>
+                <span className="text-gray-500 dark:text-gray-400">
+                  合計日数:{' '}
+                </span>
+                <span className="font-medium text-gray-900 dark:text-white">
+                  {daysDiff}日間
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/organisms/ControlPanel.tsx
+++ b/src/components/organisms/ControlPanel.tsx
@@ -10,6 +10,7 @@ import { RoomSelector } from '../molecules/RoomSelector';
 import { MessageSearch } from '../molecules/MessageSearch';
 import { MessageFilter } from '../molecules/MessageFilter';
 import { MessageSort } from '../molecules/MessageSort';
+import { MessageStatistics } from '../molecules/MessageStatistics';
 import { Button } from '../atoms/Button';
 
 interface ControlPanelProps {
@@ -93,6 +94,11 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
       {/* メッセージソート */}
       <div className="space-y-4 pb-4 border-b border-gray-200 dark:border-gray-700">
         <MessageSort />
+      </div>
+
+      {/* メッセージ統計 */}
+      <div className="space-y-4 pb-4 border-b border-gray-200 dark:border-gray-700">
+        <MessageStatistics />
       </div>
 
       {/* ダークモード設定 */}

--- a/src/utils/calculateMessageStatistics.ts
+++ b/src/utils/calculateMessageStatistics.ts
@@ -1,0 +1,77 @@
+import type { Message } from '../types';
+
+export interface MessageStatistics {
+  totalMessages: number;
+  sentMessages: number;
+  receivedMessages: number;
+  averageMessageLength: number;
+  longestMessage: number;
+  shortestMessage: number;
+  messagesPerDay: Record<string, number>;
+  messagesPerHour: Record<number, number>;
+  firstMessageDate: Date | null;
+  lastMessageDate: Date | null;
+}
+
+export const calculateMessageStatistics = (
+  messages: Message[]
+): MessageStatistics => {
+  if (messages.length === 0) {
+    return {
+      totalMessages: 0,
+      sentMessages: 0,
+      receivedMessages: 0,
+      averageMessageLength: 0,
+      longestMessage: 0,
+      shortestMessage: 0,
+      messagesPerDay: {},
+      messagesPerHour: {},
+      firstMessageDate: null,
+      lastMessageDate: null,
+    };
+  }
+
+  const sentMessages = messages.filter((msg) => msg.isSender).length;
+  const receivedMessages = messages.length - sentMessages;
+
+  // メッセージ長の統計
+  const messageLengths = messages.map((msg) => msg.content.length);
+  const totalLength = messageLengths.reduce((sum, len) => sum + len, 0);
+  const averageMessageLength = Math.round(totalLength / messages.length);
+  const longestMessage = Math.max(...messageLengths);
+  const shortestMessage = Math.min(...messageLengths);
+
+  // 日付ごとのメッセージ数
+  const messagesPerDay: Record<string, number> = {};
+  messages.forEach((msg) => {
+    const date = new Date(msg.timestamp);
+    const dateKey = date.toISOString().split('T')[0]; // YYYY-MM-DD
+    messagesPerDay[dateKey] = (messagesPerDay[dateKey] || 0) + 1;
+  });
+
+  // 時間帯ごとのメッセージ数
+  const messagesPerHour: Record<number, number> = {};
+  messages.forEach((msg) => {
+    const date = new Date(msg.timestamp);
+    const hour = date.getHours();
+    messagesPerHour[hour] = (messagesPerHour[hour] || 0) + 1;
+  });
+
+  // 最初と最後のメッセージ日時
+  const timestamps = messages.map((msg) => new Date(msg.timestamp).getTime());
+  const firstMessageDate = new Date(Math.min(...timestamps));
+  const lastMessageDate = new Date(Math.max(...timestamps));
+
+  return {
+    totalMessages: messages.length,
+    sentMessages,
+    receivedMessages,
+    averageMessageLength,
+    longestMessage,
+    shortestMessage,
+    messagesPerDay,
+    messagesPerHour,
+    firstMessageDate,
+    lastMessageDate,
+  };
+};


### PR DESCRIPTION
## Phase 25: メッセージ統計
- calculateMessageStatistics関数を実装
  - MessageStatistics型: 総数、送受信数、平均/最長/最短文字数、日別/時間帯別統計、期間情報
  - 基本統計: totalMessages, sentMessages, receivedMessages
  - メッセージ長統計: averageMessageLength, longestMessage, shortestMessage
  - アクティビティ統計: messagesPerDay, messagesPerHour
  - 期間統計: firstMessageDate, lastMessageDate
- MessageStatisticsコンポーネント作成
  - 基本統計表示: 総メッセージ数、1日平均
  - 送受信統計: 送信/受信メッセージ数
  - メッセージ長統計: 平均/最長/最短文字数
  - アクティビティ統計: 最多の日、最多の時間帯
  - 期間統計: 最初/最後のメッセージ日時、合計日数
- ControlPanelにMessageStatisticsを統合 (MessageSortの下に配置)

## 技術詳細
- useMemoで統計計算を最適化
- グリッドレイアウトで見やすいUI
- カラーコード: 送信(青)、受信(緑)
- 日本語フォーマット: ja-JP Intl.DateTimeFormat
- 空データ対応: メッセージがない場合のフォールバック表示

ビルド: 497.93 kB (gzip: 138.89 kB)
型チェック・ビルド成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)